### PR TITLE
Add Syntax Highlighting via prism-react-renderer

### DIFF
--- a/content/notebook/third-note/index.md
+++ b/content/notebook/third-note/index.md
@@ -51,3 +51,29 @@ Vestibulum molestie sollicitudin felis consectetur viverra. Proin non
 nibh ullamcorper, dignissim nunc quis, consequat enim. Vivamus suscipit 
 ante nunc, non dictum odio ullamcorper non. Etiam eu lorem eu diam 
 pulvinar porta vel nec lorem. Suspendisse at neque lectus.
+
+JavaScript code block example:
+
+```js
+// JavaScript
+const sos = () => {
+	console.log('HELP MEEEE!');
+	return 11;
+}
+```
+
+Bash code block example:
+
+```bash
+# Bash
+$ wp plugin list
+```
+
+PHP code block example:
+
+```php
+// PHP
+function test() {
+	return;
+}
+```

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,42 @@
-require('typeface-ovo');
-require('typeface-muli');
+// Fonts
+import 'typeface-ovo';
+import 'typeface-muli';
+
+// Syntax Highlighting
+import React from 'react';
+import { MDXProvider } from '@mdx-js/react';
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import dracula from 'prism-react-renderer/themes/dracula';
+import 'prismjs/plugins/command-line/prism-command-line.css';
+
+const component = {
+	pre: (props) => {
+		const className = props.children.props.className || '';
+		const matches = className.match(/language-(?<lang>.*)/);
+		return (
+			<Highlight
+				{...defaultProps}
+				code={props.children.props.children.trim()}
+				language={
+					matches && matches.groups && matches.groups.lang ? matches.groups.lang : ''
+				}
+				theme={dracula}
+			>
+				{({ className, style, tokens, getLineProps, getTokenProps }) => (
+					<pre className={className} style={style}>
+						{tokens.map((line, i) => (
+							<div {...getLineProps({ line, key: i })}>
+								{line.map((token, key) => (
+									<span {...getTokenProps({ token, key })} />
+								))}
+							</div>
+						))}
+					</pre>
+				)}
+			</Highlight>
+		);
+	},
+};
+export const wrapRootElement = ({ element }) => {
+	return <MDXProvider components={component}>{element}</MDXProvider>;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3694,6 +3694,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "clipboardy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
@@ -4621,6 +4632,12 @@
         "rimraf": "^3.0.0",
         "slash": "^3.0.0"
       }
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -8304,6 +8321,15 @@
         "ignore": "^5.1.1",
         "merge2": "^1.2.3",
         "slash": "^3.0.0"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -12916,6 +12942,19 @@
         }
       }
     },
+    "prism-react-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz",
+      "integrity": "sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug=="
+    },
+    "prismjs": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
+      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -14184,6 +14223,12 @@
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -15582,6 +15627,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "title-case": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "gatsby-plugin-emotion": "^4.3.4",
     "gatsby-plugin-mdx": "^1.2.15",
     "gatsby-source-filesystem": "^2.3.11",
+    "prism-react-renderer": "^1.1.1",
+    "prismjs": "^1.20.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "typeface-muli": "^1.1.3",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ const Button = styled(Link)`
 	border-radius: 0.4rem;
 	color: var(--background-color) !important;
 	display: inline-block;
+	font-weight: 700;
 	margin-top: 5.5rem;
 	opacity: 0.8;
 	padding: 1rem 1.5rem;
@@ -78,7 +79,7 @@ const Home = () => {
 			))}
 
 			<Button to={'/notebook'} activeClassName="active">
-				View the notebook
+				View all notes
 			</Button>
 		</Layout>
 	);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,7 @@ body {
 	font-family: 'muli', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
 		sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 	font-size: 1.8rem;
+	-webkit-font-smoothing: antialiased;
 }
 
 p {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,6 +41,11 @@ p {
 	margin: 0 0 2rem;
 }
 
+pre {
+	border-radius: 0.5rem;
+	padding: 1.5rem;
+}
+
 /* Headings */
 h1,
 h2,


### PR DESCRIPTION
Because I'm using MDX, I can not use the [`gatsby-remark-prismjs`](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/) plugin. Although that plugin is a bit more straightforward to implement, unfortunately, it does not seem to work with MDX (I confirmed it does work with regular Markdown pages).

Instead, I needed to implement the highlighting with [`prism-react-renderer`](https://github.com/FormidableLabs/prism-react-renderer).

With a little Googling, I found the following resources, which helped guide me in implementing this in a Gatsby environment:

- https://malikgabroun.com/syntax-highlighting-in-gatsby-mdx
- https://egghead.io/lessons/react-syntax-highlighting-code-blocks-using-components-with-prism-react-renderer-and-gatsby-mdx